### PR TITLE
Make ?img (?i) work with <no-embed> URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,10 @@ client.on('message', msg => {
     let url = args[0]
     const imageToAscii = require('image-to-ascii')
 
+    if (url[0] === '<' && url[url.length-1] === '>') {
+      url = url.slice(1, -1)
+    }
+
     imageToAscii(url, {
       colored: false,
       size: { height: 20 },


### PR DESCRIPTION
..by removing < and > from ?img (?i) URLs.

Previously doing `?img <http://i.imgur.com/..>` would cause a crash (protocol error). Still need to make it so that it confirms the URL is valid before requesting it!
